### PR TITLE
Support for current uport mobile app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15430,7 +15430,6 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
       "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
@@ -15439,7 +15438,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "crypto-js": {
           "version": "3.1.8",

--- a/src/components/events/checkin/EventCheckinAttestor.js
+++ b/src/components/events/checkin/EventCheckinAttestor.js
@@ -91,8 +91,6 @@ export class EventCheckinAttestor extends Component {
       }
 
       // Push the attendance credential
-      console.log('issuing claim')
-      console.log(claim)
       uport.attestCredentials({
         sub: address, claim
       })

--- a/src/components/events/checkin/EventCheckinAttestor.js
+++ b/src/components/events/checkin/EventCheckinAttestor.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react'
 import { Connect, SimpleSigner, Credentials, QRUtil } from 'uport-connect'
 import { connect } from 'react-redux'
+import { createJWT } from 'did-jwt'
 
 import { endCheckin } from './actions'
+import { uport } from '../../user'
 
 import uPortLogo from '../../../img/uport-logo.svg'
 
@@ -48,26 +50,20 @@ export class EventCheckinAttestor extends Component {
     const {identifier, ...details} = props.eventData
 
     // Build the credential to be issued to people
-    this.claim = {
-      uportLiveAttendance: details
-    }
+    this.claim = details
 
     // Create a connect instance for the Event's keypair
     const {did, privateKey} = identifier
     const signer = new SimpleSigner(privateKey)
 
-    this.eventIdentity = new Connect(details.name, {
-      credentials: new Credentials({did, signer})
-    })
+    this.eventIdentity = {issuer: did, signer}
 
     // Function to initiate the checkin flow
     this.waitForCheckin = () => {
-      this.eventIdentity.requestCredentials(
-        { requested: ['address', 'name'] }, 
-        this.updateQR
-      ).then(
-        this.doCheckin
-      )
+      uport.requestCredentials({ 
+        requested: ['address', 'name'],
+        // notifications: true
+      }, this.updateQR).then(this.doCheckin)
     }
 
     this.waitForCheckin()
@@ -88,14 +84,23 @@ export class EventCheckinAttestor extends Component {
   doCheckin({address}) {
     const {checkinCount} = this.state
 
-    // Push the attendance credential
-    this.eventIdentity.attestCredentials({
-      sub: address,
-      claim: this.claim
+    // Sign the attendee field as a JWT
+    createJWT({attendee: address}, this.eventIdentity).then((signature) => {
+      const claim = {
+        uportLiveAttendance: {...this.claim, signature}
+      }
+
+      // Push the attendance credential
+      console.log('issuing claim')
+      console.log(claim)
+      uport.attestCredentials({
+        sub: address, claim
+      })
+
+      // Update the checkin count
+      this.setState({checkinCount: checkinCount + 1})
     })
 
-    // Update the checkin count
-    this.setState({checkinCount: checkinCount + 1})
 
     // Restart the flow
     this.waitForCheckin()
@@ -107,7 +112,6 @@ export class EventCheckinAttestor extends Component {
     const {checkinCount, QR} = this.state
     const location = eventData && eventData.location
     const about = eventData && eventData.about
-    console.log(eventData)
 
     return (
       <main className="container">

--- a/src/components/events/dashboard/EventDashboard.js
+++ b/src/components/events/dashboard/EventDashboard.js
@@ -56,7 +56,7 @@ function sortEvents(events) {
 
   // Split by active/past
   for (const e of events) {
-    if (moment(e.endDate).isSameOrAfter())
+    if (moment(e.endDate).isSameOrAfter(today))
       activeEvents.push(e)
     else
       pastEvents.push(e)


### PR DESCRIPTION
Change the format of the attendance claims to support the current mobile app.  Uport-live will sign the attendance credential, but the verification will come from the `signature` field, which is a signed jwt by the event identity of the claim `{attendee: did}` where did is that of the recipient

Also slipped in the fix for allowing checkin to today's events.